### PR TITLE
Added agreeability settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ responds by validating the shit out of them.
 
 ![IKNOWRIGHT?!](usage_example.png)
 
+Sometimes responding to every trigger word is too much for some users so you 
+can turn hubot's agreeability down with the command:
+be less agreeable
+If you turn the agreeability down too far you can adjust it back up by saying:
+be more agreeable
+Agreeability setting is based on the TARS humor setting in the movie 
+Interstellar so it responds to a percentage (integer).  So, if you want to 
+set it to a specific percentage you can say:
+set agreeability to 60% 
+To query the current agreeability setting just ask:
+agreeability?
+or use any variant thereof with "agreeability?"" in the question, like:
+What is your current agreeability?
+
 ## Installation
 
 Run the following command to install this module as a Hubot dependency

--- a/README.md
+++ b/README.md
@@ -9,25 +9,35 @@ responds by validating the shit out of them.
 Sometimes responding to every trigger word is too much for some users so you 
 can turn hubot's agreeability down with the command:
 
+```
 be less agreeable
+```
 
 If you turn the agreeability down too far you can adjust it back up by saying:
 
+```
 be more agreeable
+```
 
 Agreeability setting is based on the TARS humor setting in the movie 
 Interstellar so it responds to a percentage (integer).  So, if you want to 
 set it to a specific percentage you can say:
 
+```
 set agreeability to 60% 
+```
 
 To query the current agreeability setting just ask:
 
+```
 agreeability?
+```
 
 or use any variant thereof with "agreeability?" in the question, like:
 
+```
 What is your current agreeability?
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,25 @@ responds by validating the shit out of them.
 
 Sometimes responding to every trigger word is too much for some users so you 
 can turn hubot's agreeability down with the command:
+
 be less agreeable
+
 If you turn the agreeability down too far you can adjust it back up by saying:
+
 be more agreeable
+
 Agreeability setting is based on the TARS humor setting in the movie 
 Interstellar so it responds to a percentage (integer).  So, if you want to 
 set it to a specific percentage you can say:
+
 set agreeability to 60% 
+
 To query the current agreeability setting just ask:
+
 agreeability?
-or use any variant thereof with "agreeability?"" in the question, like:
+
+or use any variant thereof with "agreeability?" in the question, like:
+
 What is your current agreeability?
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,12 +1,20 @@
 {
   "name": "hubot-ikr",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The stuff you like, Hubot likes them too",
   "main": "index.coffee",
   "author": {
   "name": "Dave Josephsen",
   "email": "dave@skeptech.org"
   },
+  "contributors": [{
+    "name": "ctn",
+    "url": "https://github.com/ctn"
+  },{
+    "name": "David McGrath",
+    "email": "dave.mcgrath3@gmail.com",
+    "url": "https://github.com/davemcg3"
+  }],
   "keywords": [
     "hubot",
     "hubot-scripts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-ikr",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The stuff you like, Hubot likes them too",
   "main": "index.coffee",
   "author": {
@@ -30,7 +30,7 @@
   },
   "dependencies": {},
     "peerDependencies": {
-      "hubot": "2.x"
+      "hubot": "3.x"
   },
   "devDependencies": {
     "mocha": "1.21.x",

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -94,13 +94,12 @@ module.exports = (robot) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     msg.reply "Current agreeability setting is " + agreeability_current
 
-  robot.hear /set agreeability to (.*)/i, (msg) ->
+  robot.hear /set agreeability to (\d{1,3})(.*)/i, (msg) ->
+    robot.logger.error msg.match[1]
+    robot.logger.error msg.match[2]
     if Number.isInteger parseInt msg.match[1]
-      robot.logger.error msg.match[1]
-      robot.logger.error parseInt msg.match[1]
-      robot.logger.error Number.isInteger parseInt msg.match[1]
-      agreeability_current = setAgreeability(robot, msg.match[1])
-      msg.reply "Current agreeability setting set to " + agreeability_current + "%"
+      agreeability_current = setAgreeability(robot, parseInt msg.match[1])
+      msg.reply "Current agreeability setting set to " + agreeability_current + "%\n" + msg.random replies
     else
       msg.reply "I'm afraid I can't do that."
 

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -87,9 +87,10 @@ module.exports = (robot) ->
 
   robot.respond /agreeability?/i, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
-    msg.reply "Current agreeability setting is " + agreeability
+    msg.reply "Current agreeability setting is " + agreeability_current
 
   robot.respond /set agreeability to (.*)/i, (msg) ->
+    robot.logger.error msg.match[1]
     if (Number.isInteger(msg.match[1]))
       agreeability_current = setAgreeability(robot, msg.match[1])
       msg.reply "Current aggreability setting set to " + agreeability_current
@@ -103,7 +104,7 @@ module.exports = (robot) ->
 
   robot.hear /be less agreeable/i, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
-    agreeability_current = setAgreeability robot, agreeability current - agreeability_step
+    agreeability_current = setAgreeability robot, agreeability_current - agreeability_step
     msg.reply "Agreeability set to " + agreeability_current
 
   robot.hear regex, (msg) ->

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -92,11 +92,9 @@ module.exports = (robot) ->
 
   robot.hear /agreeability\?/i, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
-    msg.reply "Current agreeability setting is " + agreeability_current
+    msg.reply "I'm " + agreeability_current + "% agreeable.\n" + msg.random replies
 
   robot.hear /set agreeability to (\d{1,3})(.*)/i, (msg) ->
-    robot.logger.error msg.match[1]
-    robot.logger.error msg.match[2]
     if Number.isInteger parseInt msg.match[1]
       agreeability_current = setAgreeability(robot, parseInt msg.match[1])
       msg.reply "Current agreeability setting set to " + agreeability_current + "%\n" + msg.random replies
@@ -106,12 +104,12 @@ module.exports = (robot) ->
   robot.hear /be more agreeable/i, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     agreeability_current = setAgreeability robot, agreeability_current + agreeability_step
-    msg.send msg.random replies
+    msg.reply msg.random replies
 
   robot.hear /be less agreeable/i, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     agreeability_current = setAgreeability robot, agreeability_current - agreeability_step
-    msg.reply "Aww... fine."
+    msg.reply "Aww... but I can agree to that.  ;-)"
 
   robot.hear regex, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -74,12 +74,11 @@ agreeability_min = 10 # because if smaller why bother?
 agreeability_step = 10
 agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
 
-function setAgreeability (input) {
+setAgreeability = (input) ->
   setting = Math.min(input, agreeability_max)
   setting = Math.max(setting, agreeability_min)
   robot.brain.set 'hubot_ikr_agreeability', setting
   return setting
-}
 
 
 module.exports = (robot) ->

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -90,8 +90,6 @@ module.exports = (robot) ->
     msg.reply "Current agreeability setting is " + agreeability_current
 
   robot.respond /set agreeability to (.*)/i, (msg) ->
-    robot.logger.error typeof msg.match[1]
-    robot.logger.error parseInt(msg.match[1],10)
     if (Number.isInteger(parseInt(msg.match[1])))
       agreeability_current = setAgreeability(robot, msg.match[1])
       msg.reply "Current aggreability setting set to " + agreeability_current
@@ -109,6 +107,9 @@ module.exports = (robot) ->
     msg.reply "Agreeability set to " + agreeability_current
 
   robot.hear regex, (msg) ->
-    if (Math.floor(Math.random() * 100) < agreeability_current)
+    agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
+    random_value = Math.floor(Math.random() * 100)
+    robot.logger.error random_value
+    if (random_value < agreeability_current)
       msg.send msg.random replies
 

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -39,6 +39,12 @@ replies = [
   "FOR REALSIES",
   "it's like you *literally* just read my mind right now",
   "Wow, you guys, I'm stunned",
+  "http://www.gifbin.com/bin/1237811519_chuck-norris-approves.gif",
+  "https://m.popkey.co/737465/w6yRN.gif",
+  "http://24.media.tumblr.com/tumblr_lyvq47DWd81rn95k2o1_500.gif",
+  "http://25.media.tumblr.com/tumblr_m09plvItq51rqfhi2o1_400.gif",
+  "http://memeguy.com/photos/images/when-i-tell-a-classmate-i-barley-reached-page-minimum-and-he-says-he-had-trouble-keeping-it-under--71761.gif",
+  "http://i.imgur.com/H34pBqF.gif"
 ]
 
 triggers = [
@@ -61,11 +67,45 @@ regex = new RegExp triggers.join('|'), "i"
 special_users_regex = new RegExp special_users, "i"
 special_triggers_regex = new RegExp special_triggers, "i"
 
+# agreeability setting based on TARS honesty setting from the movie Interstellar, 
+# expressed as a percentage
+agreeability_max = 100
+agreeability_min = 10 # because if smaller why bother?
+agreeability_step = 10
+agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
+
+function setAgreeability (input) {
+  setting = Math.min(input, agreeability_max)
+  setting = Math.max(setting, agreeability_min)
+  robot.brain.set 'hubot_ikr_agreeability', setting
+  return setting
+}
+
+
 module.exports = (robot) ->
   robot.hear special_triggers_regex, (msg) ->
     if (msg.message.user.name.search special_users_regex) >= 0
       msg.send msg.random replies
 
+  robot.respond /agreeability?/i, (msg) ->
+    msg.reply "Current agreeability setting is " + agreeability
+
+  robot.respond /set agreeability to (.*)/i, (msg) ->
+    if (Number.isInteger(msg.match[1]))
+      agreeability_current = setAgreeability(msg.match[1])
+      msg.reply "Current aggreability setting set to " + agreeability_current 
+    else
+      msg.reply "I'm afraid I can't do that."
+
+  robot.hear /be more agreeable/i, (msg) ->
+    agreeability_current = setAgreeability (agreeability_current + agreeability_step)
+    msg.reply "Agreeability set to " + agreeability_current
+
+  robot.hear /be less agreeable/i, (msg) ->
+    agreeability_current = setAgreeability (agreeability current - agreeability_step)
+    msg.reply "Agreeability set to " + agreeability_current
+
   robot.hear regex, (msg) ->
-    msg.send msg.random replies
+    if (Math.floor(Math.random() * 100) < agreeability_current)
+      msg.send msg.random replies
 

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -97,7 +97,7 @@ module.exports = (robot) ->
   robot.hear /set agreeability to (\d{1,3})(.*)/i, (msg) ->
     if Number.isInteger parseInt msg.match[1]
       agreeability_current = setAgreeability(robot, parseInt msg.match[1])
-      msg.reply "Current agreeability setting set to " + agreeability_current + "%\n" + msg.random replies
+      msg.reply "Okay, I'll agree with you " + agreeability_current + "% of the time.\n" + msg.random replies
     else
       msg.reply "I'm afraid I can't do that."
 

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -15,6 +15,11 @@
 #
 # Author:
 #   Dave Josephsen <dave@skeptech.org> (https://github.com/djosephsen)
+#
+# Contributors:
+#   ctn (https://github.com/ctn)
+#   David McGrath <dave.mcgrath3@gmail.com>
+#
 
 
 replies = [
@@ -67,7 +72,7 @@ regex = new RegExp triggers.join('|'), "i"
 special_users_regex = new RegExp special_users, "i"
 special_triggers_regex = new RegExp special_triggers, "i"
 
-# agreeability setting based on TARS honesty setting from the movie Interstellar,
+# agreeability setting based on TARS humor setting from the movie Interstellar,
 # expressed as a percentage
 agreeability_max = 100
 agreeability_min = 10 # because if smaller why bother?
@@ -90,21 +95,24 @@ module.exports = (robot) ->
     msg.reply "Current agreeability setting is " + agreeability_current
 
   robot.hear /set agreeability to (.*)/i, (msg) ->
-    if (Number.isInteger(parseInt(msg.match[1])))
+    if Number.isInteger parseInt msg.match[1]
+      robot.logger.error msg.match[1]
+      robot.logger.error parseInt msg.match[1]
+      robot.logger.error Number.isInteger parseInt msg.match[1]
       agreeability_current = setAgreeability(robot, msg.match[1])
-      msg.reply "Current aggreability setting set to " + agreeability_current
+      msg.reply "Current agreeability setting set to " + agreeability_current + "%"
     else
       msg.reply "I'm afraid I can't do that."
 
   robot.hear /be more agreeable/i, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     agreeability_current = setAgreeability robot, agreeability_current + agreeability_step
-    msg.reply "Agreeability set to " + agreeability_current
+    msg.send msg.random replies
 
   robot.hear /be less agreeable/i, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     agreeability_current = setAgreeability robot, agreeability_current - agreeability_step
-    msg.reply "Agreeability set to " + agreeability_current
+    msg.reply "Aww... fine."
 
   robot.hear regex, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -65,8 +65,9 @@ triggers = [
   "(excellent|fantastic|wonderful|outstanding|magnificent|brilliant|genius|amazing)",
   "(ZOMG|OMG|OMFG)",
   "\\+1",
-  "(so|pretty) great",
-  "off the hook"
+  "(so |pretty )*great",
+  "off the hook",
+  "yay"
 ]
 
 special_users = process.env.HUBOT_IKR_SPECIAL_USERS || "ctn"

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -90,8 +90,9 @@ module.exports = (robot) ->
     msg.reply "Current agreeability setting is " + agreeability_current
 
   robot.respond /set agreeability to (.*)/i, (msg) ->
-    robot.logger.error msg.match[1]
-    if (Number.isInteger(msg.match[1]))
+    robot.logger.error typeof msg.match[1]
+    robot.logger.error parseInt(msg.match[1],10)
+    if (Number.isInteger(parseInt(msg.match[1])))
       agreeability_current = setAgreeability(robot, msg.match[1])
       msg.reply "Current aggreability setting set to " + agreeability_current
     else

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -109,7 +109,7 @@ module.exports = (robot) ->
   robot.hear /be less agreeable/i, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     agreeability_current = setAgreeability robot, agreeability_current - agreeability_step
-    msg.reply "Aww... but I can agree to that.  ;-)"
+    msg.reply "Aww... but I can agree to that.  :wink:"
 
   robot.hear regex, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -85,11 +85,11 @@ module.exports = (robot) ->
     if (msg.message.user.name.search special_users_regex) >= 0
       msg.send msg.random replies
 
-  robot.respond /agreeability?/i, (msg) ->
+  robot.hear /agreeability\?/i, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     msg.reply "Current agreeability setting is " + agreeability_current
 
-  robot.respond /set agreeability to (.*)/i, (msg) ->
+  robot.hear /set agreeability to (.*)/i, (msg) ->
     if (Number.isInteger(parseInt(msg.match[1])))
       agreeability_current = setAgreeability(robot, msg.match[1])
       msg.reply "Current aggreability setting set to " + agreeability_current
@@ -108,8 +108,6 @@ module.exports = (robot) ->
 
   robot.hear regex, (msg) ->
     agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
-    random_value = Math.floor(Math.random() * 100)
-    robot.logger.error random_value
-    if (random_value < agreeability_current)
+    if (Math.floor(Math.random() * 100) < agreeability_current)
       msg.send msg.random replies
 

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -72,7 +72,6 @@ special_triggers_regex = new RegExp special_triggers, "i"
 agreeability_max = 100
 agreeability_min = 10 # because if smaller why bother?
 agreeability_step = 10
-agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
 
 setAgreeability = (robot, input) ->
   setting = Math.min(input, agreeability_max)
@@ -87,6 +86,7 @@ module.exports = (robot) ->
       msg.send msg.random replies
 
   robot.respond /agreeability?/i, (msg) ->
+    agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     msg.reply "Current agreeability setting is " + agreeability
 
   robot.respond /set agreeability to (.*)/i, (msg) ->
@@ -97,10 +97,12 @@ module.exports = (robot) ->
       msg.reply "I'm afraid I can't do that."
 
   robot.hear /be more agreeable/i, (msg) ->
+    agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     agreeability_current = setAgreeability robot, agreeability_current + agreeability_step
     msg.reply "Agreeability set to " + agreeability_current
 
   robot.hear /be less agreeable/i, (msg) ->
+    agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
     agreeability_current = setAgreeability robot, agreeability current - agreeability_step
     msg.reply "Agreeability set to " + agreeability_current
 

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -67,7 +67,7 @@ regex = new RegExp triggers.join('|'), "i"
 special_users_regex = new RegExp special_users, "i"
 special_triggers_regex = new RegExp special_triggers, "i"
 
-# agreeability setting based on TARS honesty setting from the movie Interstellar, 
+# agreeability setting based on TARS honesty setting from the movie Interstellar,
 # expressed as a percentage
 agreeability_max = 100
 agreeability_min = 10 # because if smaller why bother?
@@ -92,16 +92,16 @@ module.exports = (robot) ->
   robot.respond /set agreeability to (.*)/i, (msg) ->
     if (Number.isInteger(msg.match[1]))
       agreeability_current = setAgreeability(robot, msg.match[1])
-      msg.reply "Current aggreability setting set to " + agreeability_current 
+      msg.reply "Current aggreability setting set to " + agreeability_current
     else
       msg.reply "I'm afraid I can't do that."
 
   robot.hear /be more agreeable/i, (msg) ->
-    agreeability_current = setAgreeability (robot, agreeability_current + agreeability_step)
+    agreeability_current = setAgreeability robot, agreeability_current + agreeability_step
     msg.reply "Agreeability set to " + agreeability_current
 
   robot.hear /be less agreeable/i, (msg) ->
-    agreeability_current = setAgreeability (robot, agreeability current - agreeability_step)
+    agreeability_current = setAgreeability robot, agreeability current - agreeability_step
     msg.reply "Agreeability set to " + agreeability_current
 
   robot.hear regex, (msg) ->

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -74,7 +74,7 @@ agreeability_min = 10 # because if smaller why bother?
 agreeability_step = 10
 agreeability_current = robot.brain.get('hubot_ikr_agreeability') || 100
 
-setAgreeability = (input) ->
+setAgreeability = (robot, input) ->
   setting = Math.min(input, agreeability_max)
   setting = Math.max(setting, agreeability_min)
   robot.brain.set 'hubot_ikr_agreeability', setting
@@ -91,17 +91,17 @@ module.exports = (robot) ->
 
   robot.respond /set agreeability to (.*)/i, (msg) ->
     if (Number.isInteger(msg.match[1]))
-      agreeability_current = setAgreeability(msg.match[1])
+      agreeability_current = setAgreeability(robot, msg.match[1])
       msg.reply "Current aggreability setting set to " + agreeability_current 
     else
       msg.reply "I'm afraid I can't do that."
 
   robot.hear /be more agreeable/i, (msg) ->
-    agreeability_current = setAgreeability (agreeability_current + agreeability_step)
+    agreeability_current = setAgreeability (robot, agreeability_current + agreeability_step)
     msg.reply "Agreeability set to " + agreeability_current
 
   robot.hear /be less agreeable/i, (msg) ->
-    agreeability_current = setAgreeability (agreeability current - agreeability_step)
+    agreeability_current = setAgreeability (robot, agreeability current - agreeability_step)
     msg.reply "Agreeability set to " + agreeability_current
 
   robot.hear regex, (msg) ->

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -9,6 +9,10 @@
 #
 # Commands:
 #   enthusiastic adverbs trigger random agreements
+#   be more agreeable
+#   be less agreeable
+#   set agreeability to ##
+#   agreeability?
 #
 # Notes
 #   See jargon array for list of trigger phrases
@@ -18,7 +22,7 @@
 #
 # Contributors:
 #   ctn (https://github.com/ctn)
-#   David McGrath <dave.mcgrath3@gmail.com>
+#   David McGrath <dave.mcgrath3@gmail.com> (https://github.com/davemcg3)
 #
 
 


### PR DESCRIPTION
Sometimes hubot was too agreeable (i.e. triggered too much), so I added a setting that allows you to set a percentage of the time that hubot will agree with you, so he isn't overwhelming.  That setting is persisted in the robot.brain so you don't have to reset it every time you restart hubot.